### PR TITLE
Sha1sum keys check

### DIFF
--- a/sos/plugins/eucacore.py
+++ b/sos/plugins/eucacore.py
@@ -30,6 +30,5 @@ class eucacore(sos.plugintools.PluginBase):
         self.addCopySpec("/etc/eucalyptus")
         self.addCopySpec("/var/log/eucalyptus/*")
         if os.path.isfile('/usr/bin/sha1sum'):
-            find /var/lib/eucalyptus/keys -type f -print | xargs -I {} sha1sum {}
             self.collectExtOutput("find /var/lib/eucalyptus/keys -type f -print | xargs -I {} sha1sum {}", suggest_filename="sha1sum-eucalyptus-keys")
         return


### PR DESCRIPTION
This is a fix for issue https://github.com/eucalyptus/eucalyptus-sosreport-plugins/issues/23.  

It finds all the files under the /var/lib/eucalyptus/keys directory and does an sha1sum against each file.
