### PR TITLE
R2.2 - sha1sum check

### DIFF
--- a/sos/plugins/eucacore.py
+++ b/sos/plugins/eucacore.py
@@ -29,4 +29,6 @@ class eucacore(sos.plugintools.PluginBase):
     def setup(self):
         self.addCopySpec("/etc/eucalyptus")
         self.addCopySpec("/var/log/eucalyptus/*")
+        if os.path.isfile('/usr/bin/sha1sum'):
+            self.collectExtOutput("find /var/lib/eucalyptus/keys -type f -print | xargs -I {} sha1sum {}", suggest_filename="sha1sum-eucalyptus-keys")
         return


### PR DESCRIPTION
Merging fix for adding the ability to do a sha1sum check of all files under /var/lib/eucalyptus/keys directory - Issue https://github.com/eucalyptus/eucalyptus-sosreport-plugins/issues/23.  Confirmed fix.  Results of testing are as follows:

```
# cat odc-c-06-2013110710551383850552/sos_commands/eucacore/sha1sum-eucalyptus-keys
6ea2efa768cb42b06dba946455ba021edb65d8a3  /var/lib/eucalyptus/keys/Legend/cluster-cert.pem
7cbaaa880886f3fb47afbd577f915767834615f2  /var/lib/eucalyptus/keys/Legend/node-cert.pem
f4ad14bc91ee2c2dcab3b5baa9b416fd9b01d94f  /var/lib/eucalyptus/keys/Legend/vtunpass
9d6cc74bdecac75583eafeb6a0721b3da618ca03  /var/lib/eucalyptus/keys/Legend/cluster-pk.pem
1260de80a218613beb6c7ada72d3ca6e8a20b161  /var/lib/eucalyptus/keys/Legend/cloud-cert.pem
c0e7816bf051a218dd47a3b8c518ac9749063a2e  /var/lib/eucalyptus/keys/Legend/node-pk.pem
b5548ca8b7cd72feb8a8543fe887acb5dabbf3f1  /var/lib/eucalyptus/keys/euca.p12
f528f58b6ac6d00542f8bdc70220fc417a5d43fb  /var/lib/eucalyptus/keys/Exodus/cluster-cert.pem
a6094a72217392c649075ec334d447cc81d7f5ba  /var/lib/eucalyptus/keys/Exodus/node-cert.pem
f4ad14bc91ee2c2dcab3b5baa9b416fd9b01d94f  /var/lib/eucalyptus/keys/Exodus/vtunpass
98fa6ff3e6e04bc72fed0b40327c2d3b6afc1f62  /var/lib/eucalyptus/keys/Exodus/cluster-pk.pem
1260de80a218613beb6c7ada72d3ca6e8a20b161  /var/lib/eucalyptus/keys/Exodus/cloud-cert.pem
c672fbfa63dc6e468812253b9aa1b6f05802c661  /var/lib/eucalyptus/keys/Exodus/node-pk.pem
46f0809d28041a94ae28aa29a291d3949c1e315a  /var/lib/eucalyptus/keys/cc-client-policy.xml
acb063e340947b3c221ad8bb324c66b48793e8a1  /var/lib/eucalyptus/keys/cloud-pk.pem
6318fcf9f3f1680a7497d55943e4078127aac10e  /var/lib/eucalyptus/keys/sc-client-policy.xml
e47b17d518dcd3da3236142db9120cf53dbec725  /var/lib/eucalyptus/keys/NaturalMystic/cluster-cert.pem
54e197d48f18b591099e471e23f506dbe779eb19  /var/lib/eucalyptus/keys/NaturalMystic/node-cert.pem
f4ad14bc91ee2c2dcab3b5baa9b416fd9b01d94f  /var/lib/eucalyptus/keys/NaturalMystic/vtunpass
abd37df239d1c41a8f8eb87455e68852d3238d34  /var/lib/eucalyptus/keys/NaturalMystic/cluster-pk.pem
1260de80a218613beb6c7ada72d3ca6e8a20b161  /var/lib/eucalyptus/keys/NaturalMystic/cloud-cert.pem
2231244bde43a9976e1140e3a6f73592b2b862fe  /var/lib/eucalyptus/keys/NaturalMystic/node-pk.pem
1260de80a218613beb6c7ada72d3ca6e8a20b161  /var/lib/eucalyptus/keys/cloud-cert.pem
```
