### PR TITLE
Merge fix for removal of .hprof after collection

### DIFF
--- a/sos/plugins/eucacore.py
+++ b/sos/plugins/eucacore.py
@@ -16,6 +16,7 @@
 
 import sos.plugintools
 import os
+import glob
 
 class eucacore(sos.plugintools.PluginBase):
     """Eucalyptus Cloud - Core
@@ -31,4 +32,7 @@ class eucacore(sos.plugintools.PluginBase):
         self.addCopySpec("/var/log/eucalyptus/*")
         if os.path.isfile('/usr/bin/sha1sum'):
             self.collectExtOutput("find /var/lib/eucalyptus/keys -type f -print | xargs -I {} sha1sum {}", suggest_filename="sha1sum-eucalyptus-keys")
+        hprof_list = glob.glob('/var/log/eucalyptus/*.hprof')
+        if hprof_list:
+            self.collectExtOutput("rm -rf /var/log/eucalyptus/*.hprof", suggest_filename="hprof-removal")
         return


### PR DESCRIPTION
Testing completed of pull request https://github.com/eucalyptus/eucalyptus-sosreport-plugins/pull/43.  Results of test are as follows:

```
# ls /var/log/eucalyptus/*.hprof
ls: cannot access /var/log/eucalyptus/*.hprof: No such file or directory
# touch /var/log/eucalyptus/java_pid19832.hprof
# sosreport -o eucacore
.....
.....
Creating compressed archive...

Your sosreport has been generated and saved in:
  /tmp/sosreport-odc-c-06.9999-20131219103359-0cf5.tar.xz

The md5sum is: bc882abdf91597b09623749f176f0cf5

Please send this file to your support representative.

# ls /var/log/eucalyptus/*.hprof
ls: cannot access /var/log/eucalyptus/*.hprof: No such file or directory
# tar -Jxf sosreport-odc-c-06.9999-20131219103359-0cf5.tar.xz
# ls odc-c-06-2013121910331387478010/var/log/eucalyptus/*.hprof
odc-c-06-2013121910331387478010/var/log/eucalyptus/java_pid19832.hprof
```
